### PR TITLE
Feat/user role permissions

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,8 +1,9 @@
-import { ability } from '@saas/auth'
+import { defineAbilityFor, projectSchema } from '@saas/auth'
 
-const userCanInviteSomeoneElese = ability.can('invite', 'User')
-const userCanDeleteOtherUsers = ability.can('delete', 'User')
-const userCannotDeleteOtherUsers = ability.cannot('delete', 'User')
-console.log(userCanInviteSomeoneElese)
-console.log(userCanDeleteOtherUsers)
-console.log(userCannotDeleteOtherUsers)
+const ability = defineAbilityFor({ role: 'MEMBER', id: 'user-id' })
+
+const project = projectSchema.parse({ id: 'project-id', ownerId: 'user-id' })
+
+console.log(ability.can('get', 'Billing'))
+console.log(ability.can('create', 'Invite'))
+console.log(ability.can('delete', project))

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -16,6 +16,7 @@
   },
   "prettier": "@saas/prettier",
   "dependencies": {
-    "@casl/ability": "^6.7.2"
+    "@casl/ability": "^6.7.2",
+    "zod": "^3.24.1"
   }
 }

--- a/packages/auth/src/models/organization.ts
+++ b/packages/auth/src/models/organization.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+export const organizationSchema = z.object({
+  __typename: z.literal('Organization').default('Organization'),
+  id: z.string(),
+  ownerId: z.string(),
+})
+export type Organization = z.infer<typeof organizationSchema>

--- a/packages/auth/src/models/project.ts
+++ b/packages/auth/src/models/project.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+export const projectSchema = z.object({
+  __typename: z.literal('Project').default('Project'),
+  id: z.string(),
+  ownerId: z.string(),
+})
+export type Project = z.infer<typeof projectSchema>

--- a/packages/auth/src/models/user.ts
+++ b/packages/auth/src/models/user.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+import { roleSchema } from '../roles'
+
+export const userSchema = z.object({
+  id: z.string(),
+  role: roleSchema,
+})
+
+export type User = z.infer<typeof userSchema>

--- a/packages/auth/src/permissions.ts
+++ b/packages/auth/src/permissions.ts
@@ -1,0 +1,27 @@
+import { AbilityBuilder } from '@casl/ability'
+
+import { AppAbility } from '.'
+import { User } from './models/user'
+import { Role } from './roles'
+
+type PermissionsByRole = (
+  user: User,
+  builder: AbilityBuilder<AppAbility>
+) => void
+
+export const permissions: Record<Role, PermissionsByRole> = {
+  ADMIN(user, { can, cannot }) {
+    cannot(['transfer_ownership', 'update'], 'Organization')
+    can(['transfer_ownership', 'update'], 'Organization', {
+      ownerId: { $eq: user.id },
+    })
+  },
+  MEMBER(user, { can }) {
+    can('get', 'User')
+    can(['create', 'get'], 'Project')
+    can(['update', 'delete'], 'Project', { ownerId: { $eq: user.id } })
+  },
+  BILLING(_, { can }) {
+    can('manage', 'Billing')
+  },
+}

--- a/packages/auth/src/roles.ts
+++ b/packages/auth/src/roles.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+export const roleSchema = z.union([
+  z.literal('ADMIN'),
+  z.literal('MEMBER'),
+  z.literal('BILLING'),
+])
+export type Role = z.infer<typeof roleSchema>

--- a/packages/auth/src/subjects/billing.ts
+++ b/packages/auth/src/subjects/billing.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+export const billingSubject = z.tuple([
+  z.union([z.literal('manage'), z.literal('get'), z.literal('export')]),
+  z.literal('Billing'),
+])
+export type BillingSubject = z.infer<typeof billingSubject>

--- a/packages/auth/src/subjects/invite.ts
+++ b/packages/auth/src/subjects/invite.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+export const inviteSubject = z.tuple([
+  z.union([
+    z.literal('manage'),
+    z.literal('get'),
+    z.literal('create'),
+    z.literal('delete'),
+  ]),
+  z.literal('Invite'),
+])
+export type InviteSubject = z.infer<typeof inviteSubject>

--- a/packages/auth/src/subjects/organization.ts
+++ b/packages/auth/src/subjects/organization.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+import { organizationSchema } from '../models/organization'
+export const organizationSubject = z.tuple([
+  z.union([
+    z.literal('manage'),
+    z.literal('update'),
+    z.literal('delete'),
+    z.literal('transfer_ownership'),
+  ]),
+  z.union([z.literal('Organization'), organizationSchema]),
+])
+export type OrganizationSubject = z.infer<typeof organizationSubject>

--- a/packages/auth/src/subjects/project.ts
+++ b/packages/auth/src/subjects/project.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+import { projectSchema } from '../models/project'
+export const projectSubject = z.tuple([
+  z.union([
+    z.literal('manage'),
+    z.literal('get'),
+    z.literal('create'),
+    z.literal('update'),
+    z.literal('delete'),
+  ]),
+  z.union([z.literal('Project'), projectSchema]),
+])
+export type ProjectSubject = z.infer<typeof projectSubject>

--- a/packages/auth/src/subjects/user.ts
+++ b/packages/auth/src/subjects/user.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+export const userSubject = z.tuple([
+  z.union([
+    z.literal('manage'),
+    z.literal('get'),
+    z.literal('update'),
+    z.literal('delete'),
+  ]),
+  z.literal('User'),
+])
+export type UserSubject = z.infer<typeof userSubject>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@casl/ability':
         specifier: ^6.7.2
         version: 6.7.2
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
     devDependencies:
       '@saas/eslint-config':
         specifier: workspace:*
@@ -1468,6 +1471,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
 snapshots:
 
@@ -3003,3 +3009,5 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.24.1: {}


### PR DESCRIPTION
🔒 Implementação de Permissões Baseadas em Cargos com TypeScript e Zod

Este PR adiciona a implementação de permissões baseadas em cargos (role-based permissions) utilizando TypeScript, CASL e Zod para validação de schemas. O objetivo é garantir um controle mais granular sobre as permissões de usuários com base nos seus cargos, permitindo uma gestão mais segura e eficiente.

Principais Alterações:
Adiciona subjects (billing, invite, organization, project e user) para definir permissões de forma clara usando Zod.
Criação de schemas para organização, projeto e usuário usando Zod para validação de dados.
Implementação de role-based permissions e definição de ability management para controle de permissões baseado nos cargos de admin e membro.
Atualização de ability management para usar defineAbilityFor e projectSchema.
Adiciona o pacote Zod (v3.24.1) às dependências do projeto.

Checklist:
 Implementação de role-based permissions.
 Criação de subjects e schemas com Zod.
 Adição e configuração do pacote Zod.
 Testes básicos de permissões e validação de dados.